### PR TITLE
Incorrect variable used in Get-WsusContentSize.ps1

### DIFF
--- a/Get-WsusContentSize.ps1
+++ b/Get-WsusContentSize.ps1
@@ -42,7 +42,7 @@ $wsusContentPath   = $wsusSettingsProps.ContentDir;
 
 # Get the sum of all child files' size
 #
-$sizeProp  = Get-ChildItem -Path $contentDir -Recurse |
+$sizeProp  = Get-ChildItem -Path $wsusContentPath -Recurse |
                  Measure-Object -Property Length -Sum |
                  Select Sum;
 $sizeInGB  = $sizeProp.Sum / 1024 / 1024 / 1024;


### PR DESCRIPTION
Corrected variable used for content measure. It was using a non-existing variable, which means the size was counting from where the script was started, not the actual WSUS content folder.